### PR TITLE
Fix the `separatorIncrementer` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
-/* eslint-disable no-redeclare */
-
-declare namespace unusedFilename {
+declare namespace UnusedFilename {
 	interface Options {
 		/**
 		Custom function to increment a filename.
@@ -74,37 +72,14 @@ declare namespace unusedFilename {
 	}
 	```
 	*/
-	interface MaxTryError extends Error {
+	class MaxTryError extends Error {
 		originalPath: string;
 		lastTriedPath: string;
+		constructor(originalPath: string, lastTriedPath: string);
 	}
 }
 
 declare const unusedFilename: {
-	/**
-	Creates an incrementer that appends a number after a separator.
-
-	`separatorIncrementer('_')` will increment `file.txt` → `file_1.txt`.
-
-	Not all characters can be used as separators:
-	- On Unix-like systems, `/` is reserved.
-	- On Windows, `<>:"/|?*` along with trailing periods are reserved.
-
-	@example
-	```
-	import unusedFilename = require('unused-filename');
-
-	console.log(await unusedFilename('rainbow.txt', {incrementer: unusedFilename.separatorIncrementer('_')}));
-	//=> 'rainbow_1.txt'
-	```
-	*/
-	separatorIncrementer: (separator: string) => unusedFilename.Incrementer;
-
-	MaxTryError: unusedFilename.MaxTryError;
-
-	// TODO: Remove this for the next major release
-	default: typeof unusedFilename;
-
 	/**
 	Get an unused filename by appending a number if it exists: `file.txt` → `file (1).txt`.
 
@@ -123,7 +98,12 @@ declare const unusedFilename: {
 	})();
 	```
 	*/
-	(filePath: string, options?: unusedFilename.Options): Promise<string>;
+	(filePath: string, options?: UnusedFilename.Options): Promise<string>;
+
+	MaxTryError: new (originalPath: string, lastTriedPath: string) => UnusedFilename.MaxTryError;
+
+	// TODO: Remove this for the next major release
+	default: typeof unusedFilename;
 
 	/**
 	Synchronously get an unused filename by appending a number if it exists: `file.txt` → `file (1).txt`.
@@ -141,7 +121,26 @@ declare const unusedFilename: {
 	//=> 'rainbow (2).txt'
 	```
 	*/
-	sync(filePath: string, options?: unusedFilename.Options): string;
+	sync(filePath: string, options?: UnusedFilename.Options): string;
+
+	/**
+	Creates an incrementer that appends a number after a separator.
+
+	`separatorIncrementer('_')` will increment `file.txt` → `file_1.txt`.
+
+	Not all characters can be used as separators:
+	- On Unix-like systems, `/` is reserved.
+	- On Windows, `<>:"/|?*` along with trailing periods are reserved.
+
+	@example
+	```
+	import unusedFilename = require('unused-filename');
+
+	console.log(await unusedFilename('rainbow.txt', {incrementer: unusedFilename.separatorIncrementer('_')}));
+	//=> 'rainbow_1.txt'
+	```
+	*/
+	separatorIncrementer(separator: string): UnusedFilename.Incrementer;
 };
 
 export = unusedFilename;

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ declare namespace UnusedFilename {
 	})();
 	```
 	*/
-	type Incrementer = (filename: string, extension: string) => string;
+	type Incrementer = (filename: string, extension: string) => [string, string];
 
 	/**
 	The error thrown when `maxTries` limit is reached without finding an unused filename.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace UnusedFilename {
+declare namespace unusedFilename {
 	interface Options {
 		/**
 		Custom function to increment a filename.
@@ -72,13 +72,16 @@ declare namespace UnusedFilename {
 	}
 	```
 	*/
-	class MaxTryError extends Error {
+	/* eslint-disable @typescript-eslint/no-misused-new */
+	interface MaxTryError extends Error {
 		originalPath: string;
 		lastTriedPath: string;
-		constructor(originalPath: string, lastTriedPath: string);
+		new (originalPath: string, lastTriedPath: string): MaxTryError;
 	}
+	/* eslint-enable @typescript-eslint/no-misused-new */
 }
 
+/* eslint-disable no-redeclare */
 declare const unusedFilename: {
 	/**
 	Get an unused filename by appending a number if it exists: `file.txt` → `file (1).txt`.
@@ -98,9 +101,9 @@ declare const unusedFilename: {
 	})();
 	```
 	*/
-	(filePath: string, options?: UnusedFilename.Options): Promise<string>;
+	(filePath: string, options?: unusedFilename.Options): Promise<string>;
 
-	MaxTryError: new (originalPath: string, lastTriedPath: string) => UnusedFilename.MaxTryError;
+	MaxTryError: unusedFilename.MaxTryError;
 
 	// TODO: Remove this for the next major release
 	default: typeof unusedFilename;
@@ -121,7 +124,7 @@ declare const unusedFilename: {
 	//=> 'rainbow (2).txt'
 	```
 	*/
-	sync(filePath: string, options?: UnusedFilename.Options): string;
+	sync(filePath: string, options?: unusedFilename.Options): string;
 
 	/**
 	Creates an incrementer that appends a number after a separator.
@@ -140,7 +143,8 @@ declare const unusedFilename: {
 	//=> 'rainbow_1.txt'
 	```
 	*/
-	separatorIncrementer(separator: string): UnusedFilename.Incrementer;
+	separatorIncrementer(separator: string): unusedFilename.Incrementer;
 };
+/* eslint-enable no-redeclare */
 
 export = unusedFilename;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const separatorIncrementer = separator => {
 	return (inputFilename, extension) => {
 		const match = new RegExp(`^(?<filename>.*)${escapedSeparator}(?<index>\\d+)$`).exec(inputFilename);
 		let {filename, index} = match ? match.groups : {filename: inputFilename, index: 0};
-		return [`${filename}${extension}`, `${filename.trim()}_${++index}${extension}`];
+		return [`${filename}${extension}`, `${filename.trim()}${separator}${++index}${extension}`];
 	};
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,3 +3,8 @@ import unusedFilename = require('./index.js');
 
 expectType<Promise<string>>(unusedFilename('rainbow.txt'));
 expectType<string>(unusedFilename.sync('rainbow.txt'));
+
+let error: unknown;
+if (error instanceof unusedFilename.MaxTryError) {
+	expectType<string>(error.lastTriedPath);
+}

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import unusedFilename from './index.js';
 
 const fixturePath = file => path.join('fixtures', file);
 const underscore = {incrementer: unusedFilename.separatorIncrementer('_')};
+const dash = {incrementer: unusedFilename.separatorIncrementer('-')};
 
 test('async', async t => {
 	t.is(await unusedFilename(fixturePath('noop.txt')), fixturePath('noop.txt'));
@@ -24,6 +25,7 @@ test('async - incrementer option', async t => {
 	t.is(await unusedFilename(fixturePath('noop.txt'), underscore), fixturePath('noop.txt'));
 	t.is(await unusedFilename(fixturePath('unicorn.txt'), underscore), fixturePath('unicorn_1.txt'));
 	t.is(await unusedFilename(fixturePath('rainbow.txt'), underscore), fixturePath('rainbow_3.txt'));
+	t.is(await unusedFilename(fixturePath('rainbow.txt'), dash), fixturePath('rainbow-2.txt'));
 });
 
 test('sync', t => {
@@ -45,4 +47,5 @@ test('sync - incrementer option', t => {
 	t.is(unusedFilename.sync(fixturePath('noop.txt'), underscore), fixturePath('noop.txt'));
 	t.is(unusedFilename.sync(fixturePath('unicorn.txt'), underscore), fixturePath('unicorn_1.txt'));
 	t.is(unusedFilename.sync(fixturePath('rainbow.txt'), underscore), fixturePath('rainbow_3.txt'));
+	t.is(unusedFilename.sync(fixturePath('rainbow.txt'), dash), fixturePath('rainbow-2.txt'));
 });


### PR DESCRIPTION
Whops :x

Also fixed _some_ type complaints by typescript-eslint.

And fixed MaxTryError types. Previously only the interface was exported instead of the constructor, so it was impossible to do `instanceof MaxTryError` as TS would complain.
